### PR TITLE
Send spot instance interruption and instance state change events to SQS queue so that aws-node-termination-handler can react to them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Send spot instance interruption and instance state change events to SQS queue so that aws-node-termination-handler can react to them
+
 ## [1.1.1] - 2024-12-04
 
 ### Changed

--- a/helm/aws-nth-bundle/templates/apps.yaml
+++ b/helm/aws-nth-bundle/templates/apps.yaml
@@ -15,7 +15,7 @@ spec:
       namespace: {{ $.Release.Namespace }}
   install:
     timeout: "10m"
-  upgrade: 
+  upgrade:
     timeout: "10m"
   kubeConfig:
     context:
@@ -55,7 +55,7 @@ spec:
     inCluster: true
   name: aws-nth-crossplane-resources
   namespace: {{ $.Release.Namespace }}
-  version: 1.0.0
+  version: 1.1.0
   extraConfigs:
   - kind: configMap
     name: {{ $.Values.clusterID }}-crossplane-config


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/31843 and https://github.com/giantswarm/giantswarm/issues/32232, contains https://github.com/giantswarm/aws-nth-crossplane-resources/pull/7 released via https://github.com/giantswarm/aws-nth-crossplane-resources/pull/9.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
