### PR TITLE
Upgrade aws-nth-crossplane-resources to v1.1.1, supporting multiple OIDC providers in the NTH IAM role as required for cleanup of migrated vintage clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade aws-nth-crossplane-resources to v1.1.1, supporting multiple OIDC providers in the NTH IAM role as required for cleanup of migrated vintage clusters
+
 ## [1.2.2] - 2025-07-03
 
 ### Changed

--- a/helm/aws-nth-bundle/templates/apps.yaml
+++ b/helm/aws-nth-bundle/templates/apps.yaml
@@ -26,6 +26,8 @@ spec:
       namespace: {{ $.Release.Namespace}}
   name: aws-node-termination-handler
   namespace: kube-system
+  # used by renovate
+  # repo: giantswarm/aws-node-termination-handler-app
   version: 1.21.0
   extraConfigs:
   - kind: configMap
@@ -60,7 +62,9 @@ spec:
     inCluster: true
   name: aws-nth-crossplane-resources
   namespace: {{ $.Release.Namespace }}
-  version: 1.1.0
+  # used by renovate
+  # repo: giantswarm/aws-nth-crossplane-resources
+  version: 1.1.1
   extraConfigs:
   - kind: configMap
     name: {{ $.Values.clusterID }}-crossplane-config


### PR DESCRIPTION
See https://github.com/giantswarm/giantswarm/issues/34400

Also add renovate automation to ensure we don't forget about these bumps again.