### PR TITLE
Bump aws-node-termination-handler-app and aws-nth-crossplane-resources to support sending heartbeats and fix support for multiple OIDC providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade aws-nth-crossplane-resources to v1.3.0, fixing support for multiple OIDC providers in the NTH IAM role as required for cleanup of migrated vintage clusters, and supporting heartbeat sending
+- Upgrade aws-node-termination-handler-app to v1.23.0, enabling heartbeats by default and upgrading to upstream application version v1.25.2 which fixes a resource leak bug relevant to heartbeat sending
+
 ## [1.2.3] - 2025-10-01
 
 ### Changed

--- a/helm/aws-nth-bundle/templates/apps.yaml
+++ b/helm/aws-nth-bundle/templates/apps.yaml
@@ -28,7 +28,7 @@ spec:
   namespace: kube-system
   # used by renovate
   # repo: giantswarm/aws-node-termination-handler-app
-  version: 1.21.0
+  version: 1.23.0
   extraConfigs:
   - kind: configMap
     name: {{ $.Values.clusterID }}-crossplane-config
@@ -64,7 +64,7 @@ spec:
   namespace: {{ $.Release.Namespace }}
   # used by renovate
   # repo: giantswarm/aws-nth-crossplane-resources
-  version: 1.1.1
+  version: 1.3.0
   extraConfigs:
   - kind: configMap
     name: {{ $.Values.clusterID }}-crossplane-config


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/32232 and https://github.com/giantswarm/giantswarm/issues/34400