### PR TITLE
Add dependsOn for prometheus-operator-crd HelmRelease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `cluster.x-k8s.io/cluster-name` label to the HelmReleases.
+- Add Flux `dependsOn` from the `aws-node-termination-handler` HelmRelease to the `prometheus-operator-crd` HelmRelease.
 
 ### Changed
 

--- a/helm/aws-nth-bundle/templates/helmreleases.yaml
+++ b/helm/aws-nth-bundle/templates/helmreleases.yaml
@@ -26,6 +26,8 @@ spec:
   releaseName: aws-node-termination-handler
   targetNamespace: kube-system
   storageNamespace: kube-system
+  dependsOn:
+  - name: {{ $.Values.clusterID }}-prometheus-operator-crd
   chartRef:
     kind: OCIRepository
     name: {{ $.Values.clusterID }}-aws-node-termination-handler


### PR DESCRIPTION
Adds a Flux `dependsOn` from the `aws-node-termination-handler` HelmRelease to the `prometheus-operator-crd` HelmRelease. The aws-node-termination-handler chart includes ServiceMonitor resources that require the Prometheus Operator CRDs to be present, so this dependency ensures install ordering.
