### PR TITLE
Add configurable dependsOn list for aws-node-termination-handler HelmRelease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Make the `aws-node-termination-handler` HelmRelease `dependsOn` list configurable via `awsNodeTerminationHandler.dependsOn`.
+
 ## [2.0.0] - 2026-05-06
 
 ## [1.5.0] - 2026-05-05

--- a/helm/aws-nth-bundle/templates/helmreleases.yaml
+++ b/helm/aws-nth-bundle/templates/helmreleases.yaml
@@ -24,10 +24,15 @@ spec:
   releaseName: aws-node-termination-handler
   targetNamespace: kube-system
   storageNamespace: kube-system
+{{- with (($.Values.awsNodeTerminationHandler).dependsOn) }}
   dependsOn:
-  - name: {{ $.Values.clusterID }}-prometheus-operator-crd
-  - name: {{ $.Values.clusterID }}-aws-pod-identity-webhook
-  - name: {{ $.Values.clusterID }}-kyverno-crds
+  {{- range . }}
+  - name: {{ $.Values.clusterID }}-{{ .name }}
+    {{- if .namespace }}
+    namespace: {{ .namespace }}
+    {{- end }}
+  {{- end }}
+{{- end }}
   chartRef:
     kind: OCIRepository
     name: {{ $.Values.clusterID }}-aws-node-termination-handler

--- a/helm/aws-nth-bundle/values.schema.json
+++ b/helm/aws-nth-bundle/values.schema.json
@@ -14,6 +14,26 @@
         },
         "region": {
             "type": "string"
+        },
+        "awsNodeTerminationHandler": {
+            "type": "object",
+            "properties": {
+                "dependsOn": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["name"]
+                    }
+                }
+            }
         }
     }
 }

--- a/helm/aws-nth-bundle/values.yaml
+++ b/helm/aws-nth-bundle/values.yaml
@@ -2,3 +2,11 @@ ociRepositoryUrl: oci://gsoci.azurecr.io/charts/giantswarm/aws-node-termination-
 clusterID: ""
 managementCluster: ""
 region: ""
+
+awsNodeTerminationHandler:
+  # HelmReleases that the subchart aws-node-termination-handler HelmRelease depends on. Each `name`
+  # is automatically prefixed with `clusterID` to match the bundle's HelmRelease naming convention.
+  dependsOn:
+    - name: prometheus-operator-crd
+    - name: aws-pod-identity-webhook
+    - name: kyverno-crds


### PR DESCRIPTION
Make the `aws-node-termination-handler` HelmRelease `dependsOn` list configurable via `awsNodeTerminationHandler.dependsOn`.

This is needed for EKS clusters that do not deploy the aws-pod-identity-webhook app