### PR TITLE
feat: use gsoci to pull the NTH container image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,8 @@ workflows:
           name: package and push aws-node-termination-handler chart
           app_catalog: default-catalog
           app_catalog_test: default-test-catalog
+          override_app_version: false
+          override_chart_version: true
           chart: aws-node-termination-handler
           explicit_allow_chart_name_mismatch: true
           ct_config: ".circleci/ct-config.yaml"
@@ -31,5 +33,7 @@ workflows:
           name: package and push aws-nth-bundle chart
           app_catalog: default-catalog
           app_catalog_test: default-test-catalog
+          override_app_version: true
+          override_chart_version: true
           chart: aws-nth-bundle
           <<: *job_filters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `gsoci.azurecr.io/giantswarm/aws-node-termination-handler` for the container image.
+- Fix the Flux HelmRelease remediation policy (always remediate).
+
 ## [2.0.1] - 2026-05-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Here we define the `aws-nth-bundle` and `aws-node-termination-handler` charts wi
 |------|---------------|--------------|
 | **BUNDLE-ONLY** | Management cluster only | Never forwarded to workload chart. Examples: `clusterID`, `ociRepositoryUrl` |
 | **UPSTREAM** | Workload cluster, under `upstream:` key | Routed to the unmodified upstream subchart. Controls the actual NTH application: image, replicas, service account, SQS settings, etc. |
-| **EXTRAS** | Workload cluster, at top level (not under `upstream:`) | Consumed by GS extras templates: `networkPolicy`, `verticalPodAutoscaler`, `global.podSecurityStandards`, etc. |
+| **EXTRAS** | Workload cluster, at top level (not under `upstream:`) | Consumed by GS extras templates: `networkPolicy`, `verticalPodAutoscaler`, etc. |
 
 ## Architecture
 

--- a/helm/aws-node-termination-handler/templates/pss-exceptions.yaml
+++ b/helm/aws-node-termination-handler/templates/pss-exceptions.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.podSecurityStandards.enforced }}
 apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
@@ -25,4 +24,3 @@ spec:
         - {{ .Release.Name }}-aws-node-termination-handler-*
         kinds:
         - Pod
-{{- end }}

--- a/helm/aws-node-termination-handler/values.schema.json
+++ b/helm/aws-node-termination-handler/values.schema.json
@@ -14,10 +14,6 @@
         "verticalPodAutoscaler": {
             "type": "object",
             "additionalProperties": true
-        },
-        "global": {
-            "type": "object",
-            "additionalProperties": true
         }
     }
 }

--- a/helm/aws-node-termination-handler/values.yaml
+++ b/helm/aws-node-termination-handler/values.yaml
@@ -2,6 +2,9 @@
 upstream:
   nameOverride: aws-node-termination-handler
 
+  image:
+    repository: gsoci.azurecr.io/giantswarm/aws-node-termination-handler
+
 # --- EXTRAS ---------------------------------------------------------------------
 networkPolicy:
   enabled: true

--- a/helm/aws-node-termination-handler/values.yaml
+++ b/helm/aws-node-termination-handler/values.yaml
@@ -17,7 +17,3 @@ verticalPodAutoscaler:
   minAllowed:
     cpu: 50m
     memory: 50Mi
-
-global:
-  podSecurityStandards:
-    enforced: true

--- a/helm/aws-nth-bundle/templates/helmreleases.yaml
+++ b/helm/aws-nth-bundle/templates/helmreleases.yaml
@@ -44,11 +44,9 @@ spec:
   install:
     remediation:
       retries: -1
-      remediateLastFailure: false
   upgrade:
     remediation:
-      retries: 0
-      remediateLastFailure: false
+      retries: -1
   values:
     upstream:
       enableSqsTerminationDraining: true


### PR DESCRIPTION
- Use `gsoci.azurecr.io/giantswarm/aws-node-termination-handler` for the container image.
- Fix the Flux HelmRelease remediation policy (always remediate).

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
